### PR TITLE
Fem 2308 - Phoenix Provider works with old API version - Need to upgrade in order to support KalturaLiveAsset

### DIFF
--- a/Sources/Base/RequestExtension.swift
+++ b/Sources/Base/RequestExtension.swift
@@ -11,7 +11,7 @@
 import UIKit
 import SwiftyJSON
 import KalturaNetKit
-
+import PlayKit
 
 extension KalturaRequestBuilder {
     
@@ -35,14 +35,14 @@ extension KalturaRequestBuilder {
     
     @discardableResult
     internal func setOTTBasicParams() -> Self {
-        self.setClientTag(clientTag: "java:16-09-10")
-        self.setApiVersion(apiVersion: "3.6.1078.11798")
+        self.setClientTag(clientTag: PlayKitManager.clientTag)
+        self.setApiVersion(apiVersion: "5.0.3.18074")
         return self
     }
     
     @discardableResult
     internal func setOVPBasicParams() -> Self {
-        self.setClientTag(clientTag: "playkit")
+        self.setClientTag(clientTag: PlayKitManager.clientTag)
         self.setApiVersion(apiVersion: "3.3.0")
         self.setFormat(format: 1)
         return self

--- a/Sources/OTT/Model/OTTLiveAsset.swift
+++ b/Sources/OTT/Model/OTTLiveAsset.swift
@@ -1,0 +1,12 @@
+//
+//  OTTLiveAsset.swift
+//  KalturaNetKit
+//
+//  Created by Nilit Danan on 12/2/18.
+//
+
+import Foundation
+
+public class OTTLiveAsset: OTTMediaAsset {
+    
+}

--- a/Sources/OTT/Model/OTTLiveAsset.swift
+++ b/Sources/OTT/Model/OTTLiveAsset.swift
@@ -1,9 +1,3 @@
-//
-//  OTTLiveAsset.swift
-//  KalturaNetKit
-//
-//  Created by Nilit Danan on 12/2/18.
-//
 
 import Foundation
 

--- a/Sources/OTT/Parsers/OTTObjectMapper.swift
+++ b/Sources/OTT/Parsers/OTTObjectMapper.swift
@@ -33,6 +33,8 @@ class OTTObjectMapper: NSObject {
                 return OTTMediaFile.self
             case "KalturaMultilingualStringValue":
                 return OTTMultilingualStringValue.self
+            case "KalturaLiveAsset":
+                return OTTLiveAsset.self
             default:
                 return nil
             }

--- a/Sources/OTT/Provider/PhoenixMediaProvider.swift
+++ b/Sources/OTT/Provider/PhoenixMediaProvider.swift
@@ -565,6 +565,10 @@ public enum PhoenixMediaProviderError: PKError {
             mediaEntry.tags = tags
         }
         
+        if let _ = asset as? OTTLiveAsset  {
+            mediaEntry.mediaType = .live
+        }
+        
         return (mediaEntry, nil)
     }
     


### PR DESCRIPTION
Updated to BE version 5.0.3.18074.
Fixed client tag which was incorrect.
Added OTTLiveAsset for KalturaLiveAsset.
Set the mediaEntry mediaType to live if the asset returned as OTTLiveAsset.