### PR TITLE
Fem 2341 Perform seek to live edge inside PlayKit upon Live media

### DIFF
--- a/PlayKitProviders.podspec
+++ b/PlayKitProviders.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Sources/**/*'
   
-  s.dependency 'PlayKit/AnalyticsCommon', '~> 3.7.0' + suffix
+  s.dependency 'PlayKit/AnalyticsCommon', '~> 3.8.0' + suffix
     
   s.dependency 'KalturaNetKit'
   s.dependency 'PlayKitUtils'

--- a/Sources/OTT/Provider/PhoenixMediaProvider.swift
+++ b/Sources/OTT/Provider/PhoenixMediaProvider.swift
@@ -569,6 +569,10 @@ public enum PhoenixMediaProviderError: PKError {
             mediaEntry.mediaType = .live
         }
         
+        if loaderInfo.assetType == .epg && loaderInfo.playbackContextType == .startOver {
+            mediaEntry.mediaType = .dvrLive
+        }
+        
         return (mediaEntry, nil)
     }
     

--- a/Sources/OVP/Model/OVPLiveStreamEntry.swift
+++ b/Sources/OVP/Model/OVPLiveStreamEntry.swift
@@ -21,6 +21,6 @@ class OVPLiveStreamEntry: OVPEntry {
         super.init(json: json)
         
         let jsonObject = JSON(json)
-        self.dvrStatus = jsonObject[dvrStatusKey].bool
+        self.dvrStatus = Bool(exactly: jsonObject[dvrStatusKey].numberValue)
     }
 }

--- a/Sources/OVP/Provider/OVPMediaProvider.swift
+++ b/Sources/OVP/Provider/OVPMediaProvider.swift
@@ -290,6 +290,11 @@ import PlayKit
                     mediaEntry.metadata = metaDataItems
                     mediaEntry.tags = entry.tags
                     mediaEntry.mediaType = self.mediaType(of: entry.entryType())
+
+                    if let liveEntry = entry as? OVPLiveStreamEntry, liveEntry.dvrStatus == true {
+                        mediaEntry.mediaType = .dvrLive
+                    }
+                    
                     callback(mediaEntry, nil)
                 })
             

--- a/Sources/OVP/Services/OVPBaseEntryService.swift
+++ b/Sources/OVP/Services/OVPBaseEntryService.swift
@@ -18,7 +18,8 @@ class OVPBaseEntryService {
     internal static func list(baseURL: String, ks: String,entryID: String) -> KalturaRequestBuilder? {
         
         if let request: KalturaRequestBuilder = KalturaRequestBuilder(url: baseURL, service: "baseEntry", action: "list") {
-            let responseProfile = ["fields": "mediaType,dataUrl,id,name,duration,msDuration,flavorParamsIds,tags", "type": 1] as [String: Any]
+            let responseProfile = ["fields": "mediaType,dataUrl,id,name,duration,msDuration,flavorParamsIds,tags,dvrStatus",
+                                   "type": 1] as [String: Any]
             request.setBody(key: "ks", value: JSON(ks))
                 .setBody(key: "responseProfile", value: JSON(responseProfile))
                 .setBody(key: "filter:redirectFromEntryId", value: JSON(entryID))


### PR DESCRIPTION
OVP:
Fixed dvrStatus parsed incorrectly.
Added the missing dvrStatus to the request fields.
Setting the mediaType to dvrLive if dvrStatus on the LiveStreamEntry came back true.

OTT:
Set mediaType to dvrLive if the assetType is epg and the playbackContextType is startOver.