### PR TITLE
FEM-2417: OTT bookmarks - prevent stop twice on destroy

### DIFF
--- a/Sources/OTT/Analytics/BaseOTTAnalyticsPlugin.swift
+++ b/Sources/OTT/Analytics/BaseOTTAnalyticsPlugin.swift
@@ -129,6 +129,7 @@ public class BaseOTTAnalyticsPlugin: BasePlugin, OTTAnalyticsPluginProtocol, App
                 self.messageBus?.addObserver(self, events: [e.self]) { [weak self] event in
                     guard let self = self else { return }
                     self.cancelTimer()
+                    // If destory was already called, it may have sent stop. Don't send it again.
                     if !self.stopSentByDestroy {
                         self.sendAnalyticsEvent(ofType: .stop)
                     }


### PR DESCRIPTION
Because of the event dispatching order, destroy is handled by the plugin before stop. Then, in the next time stop is sent it contains an incorrect position.

The workaround is that if destroy has sent the stop event, stop will not send it again.

This behavior needs to be revisited if/when there's a change in event dispatching order.