### PR TITLE
FEM-2662 Add OTT provider KalturaAsset type npvr

### DIFF
--- a/PlayKitProviders.podspec
+++ b/PlayKitProviders.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Sources/**/*'
   
-  s.dependency 'PlayKit/AnalyticsCommon'
+  s.dependency 'PlayKit/AnalyticsCommon', '~> 3.11'
     
   s.dependency 'KalturaNetKit'
   s.dependency 'PlayKitUtils'

--- a/Sources/Base/RequestExtension.swift
+++ b/Sources/Base/RequestExtension.swift
@@ -36,7 +36,7 @@ extension KalturaRequestBuilder {
     @discardableResult
     internal func setOTTBasicParams() -> Self {
         self.setClientTag(clientTag: PlayKitManager.clientTag)
-        self.setApiVersion(apiVersion: "5.0.3.18074")
+        self.setApiVersion(apiVersion: "5.2.4")
         return self
     }
     

--- a/Sources/OTT/Model/OTTBooleanValue.swift
+++ b/Sources/OTT/Model/OTTBooleanValue.swift
@@ -1,0 +1,16 @@
+
+import Foundation
+import SwiftyJSON
+
+class OTTBooleanValue: OTTBaseObject {
+    
+    var value: Bool?
+    
+    let valueKey = "value"
+    
+    required init?(json: Any) {
+        if let jsonDictionary = JSON(json).dictionary {
+            self.value = jsonDictionary[valueKey]?.bool
+        }
+    }
+}

--- a/Sources/OTT/Model/OTTMediaAsset.swift
+++ b/Sources/OTT/Model/OTTMediaAsset.swift
@@ -25,14 +25,20 @@ fileprivate let mediaFilesKey = "mediaFiles"
 fileprivate let metasKey = "metas"
 
 public class OTTMediaAsset: OTTBaseObject {
-    // This class is for both KalturaMediaAsset and KalturaProgramAsset, because
-    // the fields we use are common between them.
     
+    /**  Unique identifier for the asset  */
     var id: Int?
+    /**  Identifies the asset type (EPG, Recording, Movie, TV Series, etc).
+    Possible values: 0 – EPG linear programs, 1 - Recording; or any asset type ID
+    according to the asset types IDs defined in the system.  */
     var type: Int?
+    /**  Asset name  */
     var name: String?
+    /**  Files  */
     var mediaFiles: [OTTMediaFile] = []
-    var metas: Dictionary<String, OTTBaseObject> = Dictionary()
+    /**  Dynamic collection of key-value pairs according to the String Meta defined in
+    the system  */
+    var metas: [String: OTTBaseObject] = [:]
     
     public required init?(json: Any) {
         let jsonObj: JSON = JSON(json)

--- a/Sources/OTT/Model/OTTMultilingualStringValue.swift
+++ b/Sources/OTT/Model/OTTMultilingualStringValue.swift
@@ -8,12 +8,6 @@
 // https://www.gnu.org/licenses/agpl-3.0.html
 // ===================================================================================================
 
-//
-//  OTTMultilingualStringValue.swift
-//  PlayKit
-//
-//  Created by Nilit Danan on 8/20/18.
-//
 
 import Foundation
 import SwiftyJSON

--- a/Sources/OTT/Model/OTTProgramAsset.swift
+++ b/Sources/OTT/Model/OTTProgramAsset.swift
@@ -1,0 +1,51 @@
+
+import Foundation
+import SwiftyJSON
+
+fileprivate let epgChannelIdKey = "epgChannelId"
+fileprivate let epgIdKey = ""
+fileprivate let relatedMediaIdKey = ""
+fileprivate let cridKey = ""
+fileprivate let linearAssetIdKey = ""
+fileprivate let enableCdvrKey = ""
+fileprivate let enableCatchUpKey = ""
+fileprivate let enableStartOverKey = ""
+fileprivate let enableTrickPlayKey = ""
+
+public class OTTProgramAsset: OTTMediaAsset {
+    
+    /**  EPG channel identifier  */
+    public var epgChannelId: Int64?
+    /**  EPG identifier  */
+    public var epgId: String?
+    /**  Ralated media identifier  */
+    public var relatedMediaId: Int64?
+    /**  Unique identifier for the program  */
+    public var crid: String?
+    /**  Id of linear media asset  */
+    public var linearAssetId: Int64?
+    /**  Is CDVR enabled for this asset  */
+    public var enableCdvr: Bool?
+    /**  Is catch-up enabled for this asset  */
+    public var enableCatchUp: Bool?
+    /**  Is start over enabled for this asset  */
+    public var enableStartOver: Bool?
+    /**  Is trick-play enabled for this asset  */
+    public var enableTrickPlay: Bool?
+    
+    public required init?(json: Any) {
+        super.init(json: json)
+        
+        let jsonObj: JSON = JSON(json)
+        
+        self.epgChannelId = jsonObj[epgChannelIdKey].int64
+        self.epgId = jsonObj[epgIdKey].string
+        self.relatedMediaId = jsonObj[relatedMediaIdKey].int64
+        self.crid = jsonObj[cridKey].string
+        self.linearAssetId = jsonObj[linearAssetIdKey].int64
+        self.enableCdvr = jsonObj[enableCdvrKey].bool
+        self.enableCatchUp = jsonObj[enableCatchUpKey].bool
+        self.enableStartOver = jsonObj[enableStartOverKey].bool
+        self.enableTrickPlay = jsonObj[enableTrickPlayKey].bool
+    }
+}

--- a/Sources/OTT/Model/OTTRecordingAsset.swift
+++ b/Sources/OTT/Model/OTTRecordingAsset.swift
@@ -1,0 +1,30 @@
+
+import Foundation
+import SwiftyJSON
+
+fileprivate let recordingIdKey = "recordingId"
+fileprivate let recordingTypeKey = "recordingType"
+
+public enum RecordingType: String {
+    case single = "SINGLE"
+    case season = "SEASON"
+    case series = "SERIES"
+}
+
+public class OTTRecordingAsset: OTTProgramAsset {
+    /**  Recording identifier  */
+    public var recordingId: String?
+    /**  Recording Type: single/season/series  */
+    public var recordingType: RecordingType?
+    
+    public required init?(json: Any) {
+        super.init(json: json)
+        
+        let jsonObj: JSON = JSON(json)
+        
+        self.recordingId = jsonObj[recordingIdKey].string
+        if let type = jsonObj[recordingTypeKey].string {
+            self.recordingType = RecordingType(rawValue: type)
+        }
+    }
+}

--- a/Sources/OTT/Parsers/OTTObjectMapper.swift
+++ b/Sources/OTT/Parsers/OTTObjectMapper.swift
@@ -27,14 +27,20 @@ class OTTObjectMapper: NSObject {
                 return OTTPlaybackSource.self
             case "KalturaPlaybackContext":
                 return OTTPlaybackContext.self
-            case "KalturaMediaAsset", "KalturaProgramAsset":
+            case "KalturaMediaAsset":
                 return OTTMediaAsset.self
+            case "KalturaProgramAsset":
+                return OTTProgramAsset.self
             case "KalturaMediaFile":
                 return OTTMediaFile.self
             case "KalturaMultilingualStringValue":
                 return OTTMultilingualStringValue.self
+            case "KalturaBooleanValue":
+                return OTTBooleanValue.self
             case "KalturaLiveAsset":
                 return OTTLiveAsset.self
+            case "KalturaRecordingAsset":
+                return OTTRecordingAsset.self
             default:
                 return nil
             }

--- a/Sources/OTT/Provider/PhoenixMediaProvider.swift
+++ b/Sources/OTT/Provider/PhoenixMediaProvider.swift
@@ -563,6 +563,8 @@ public enum PhoenixMediaProviderError: PKError {
         let mediaEntry = PKMediaEntry(loaderInfo.assetId, sources: mediaSources, duration: TimeInterval(maxDuration))
         mediaEntry.name = asset?.name
         
+        mediaEntry.metadata = createMetadata(from: asset)
+        
         let metadata = asset?.arrayOfMetas()
         if let tags = metadata?["tags"] {
             mediaEntry.tags = tags
@@ -577,6 +579,17 @@ public enum PhoenixMediaProviderError: PKError {
         }
         
         return (mediaEntry, nil)
+    }
+    
+    static func createMetadata(from asset: OTTMediaAsset?) -> [String: String] {
+        var metadata: [String: String] = asset?.arrayOfMetas() ?? [:]
+        
+        if let recordingAsset = asset as? OTTRecordingAsset {
+            metadata["recordingId"] = recordingAsset.recordingId
+            metadata["recordingType"] = recordingAsset.recordingType.map { $0.rawValue }
+        }
+        
+        return metadata
     }
     
     // Mapping between server scheme and local definision of scheme

--- a/Sources/OTT/Provider/PhoenixMediaProvider.swift
+++ b/Sources/OTT/Provider/PhoenixMediaProvider.swift
@@ -192,7 +192,7 @@ public enum PhoenixMediaProviderError: PKError {
         return self
     }
     
-    /// - Parameter type: Asset Object type if it is Media Or EPG
+    /// - Parameter type: Asset Object type if it is EPG, Recording or Media
     /// - Returns: Self
     @discardableResult
     @nonobjc public func set(type: AssetType) -> Self {
@@ -316,6 +316,8 @@ public enum PhoenixMediaProviderError: PKError {
                 self.refType = .media   // default if type is media
             case .epg:
                 self.refType = .epgInternal
+            case .recording:
+                self.refType = .npvr
             default:
                 break
             }

--- a/Sources/OTT/Provider/PhoenixMediaProvider.swift
+++ b/Sources/OTT/Provider/PhoenixMediaProvider.swift
@@ -43,6 +43,7 @@ import PlayKit
     case media
     case epgInternal
     case epgExternal
+    case npvr
     case unset
     
     public var description: String {
@@ -50,6 +51,7 @@ import PlayKit
         case .media: return "media"
         case .epgInternal: return "epgInternal"
         case .epgExternal: return "epgExternal"
+        case .npvr: return "npvr"
         case .unset: return "<unset>"
         }
     }
@@ -537,7 +539,7 @@ public enum PhoenixMediaProviderError: PKError {
                         // if the scheme is type fair play and there is no certificate or license URL
                         guard let certifictae = drmData.certificate
                             else { return nil }
-                        return FairPlayDRMParams(licenseUri: drmData.licenseURL, scheme: scheme, base64EncodedCertificate: certifictae)
+                        return FairPlayDRMParams(licenseUri: drmData.licenseURL, base64EncodedCertificate: certifictae)
                     default:
                         return DRMParams(licenseUri: drmData.licenseURL, scheme: scheme)
                     }
@@ -614,6 +616,8 @@ public enum PhoenixMediaProviderError: PKError {
             return .epgInternal
         case .epgExternal:
             return .epgExternal
+        case .npvr:
+            return .npvr
         case .unset:
             return nil
         }

--- a/Sources/OTT/Services/OTTAssetService.swift
+++ b/Sources/OTT/Services/OTTAssetService.swift
@@ -23,7 +23,7 @@ class OTTAssetService {
         return request
             .setBody(key: "assetId", value: JSON(assetId))
             .setBody(key: "ks", value: JSON(ks))
-            .setBody(key: "assetType", value: JSON(type.asString))
+            .setBody(key: "assetType", value: JSON(type.description))
             .setBody(key: "contextDataParams", value: JSON(playbackContextOptions.toDictionary()))
     }
     
@@ -36,7 +36,7 @@ class OTTAssetService {
         return request
             .setBody(key: "ks", value: JSON(ks))
             .setBody(key: "id", value: JSON(assetId))
-            .setBody(key: "assetReferenceType", value: JSON(refType.asString))
+            .setBody(key: "assetReferenceType", value: JSON(refType.description))
     }
 }
 
@@ -50,7 +50,7 @@ struct PlaybackContextOptions {
     func toDictionary() -> [String: Any] {
 
         var dict: [String: Any] = [:]
-        dict["context"] = playbackContextType.asString
+        dict["context"] = playbackContextType.description
         dict["mediaProtocols"] = protocls
         if let fileIds = self.assetFileIds {
             dict["assetFileIds"] = fileIds.joined(separator: ",")

--- a/Sources/OTT/Services/PhoenixAPIDefines.swift
+++ b/Sources/OTT/Services/PhoenixAPIDefines.swift
@@ -11,12 +11,12 @@
 import Foundation
 
 
-enum AssetTypeAPI: Int {
+enum AssetTypeAPI: Int, CustomStringConvertible {
     case media
     case epg
     case recording
     
-    var asString: String {
+    var description: String {
         switch self {
         case .media: return "media"
         case .epg: return "epg"
@@ -25,28 +25,30 @@ enum AssetTypeAPI: Int {
     }
 }
 
-enum AssetReferenceTypeAPI: Int {
+enum AssetReferenceTypeAPI: Int, CustomStringConvertible {
     case media
     case epgInternal
     case epgExternal
+    case npvr
     
-    var asString: String {
+    var description: String {
         switch self {
         case .media: return "media"
         case .epgInternal: return "epg_internal"
         case .epgExternal: return "epg_external"
+        case .npvr: return "npvr"
         }
     }
 }
 
-enum PlaybackTypeAPI: Int {
+enum PlaybackTypeAPI: Int, CustomStringConvertible {
     
     case trailer
     case catchup
     case startOver
     case playback
     
-    var asString: String {
+    var description: String {
         switch self {
         case .trailer: return "TRAILER"
         case .catchup: return "CATCHUP"

--- a/Sources/OTT/Services/PhoenixAPIDefines.swift
+++ b/Sources/OTT/Services/PhoenixAPIDefines.swift
@@ -10,11 +10,11 @@
 
 import Foundation
 
-
+//  0 – EPG linear programs; 1 - Recording; any asset type ID according to the asset types IDs defined in the system - Media.
 enum AssetTypeAPI: Int, CustomStringConvertible {
-    case media
     case epg
     case recording
+    case media
     
     var description: String {
         switch self {

--- a/Sources/OVP/Provider/OVPMediaProvider.swift
+++ b/Sources/OVP/Provider/OVPMediaProvider.swift
@@ -347,7 +347,7 @@ import PlayKit
             switch scheme {
             case .fairplay :
                 guard let certifictae = drm.certificate, let licenseURL = drm.licenseURL else { return nil }
-                drmData = FairPlayDRMParams(licenseUri: licenseURL, scheme:scheme, base64EncodedCertificate: certifictae)
+                drmData = FairPlayDRMParams(licenseUri: licenseURL, base64EncodedCertificate: certifictae)
             default:
                 drmData = DRMParams(licenseUri: drm.licenseURL, scheme: scheme)
             }


### PR DESCRIPTION
Added npvr to the AssetReferenceTypes.
Created a separated class for the KalturaProgramAsset cause it is a subclass for the KalturaRecordingAsset.
Updated the BE API version to 5.2.4.
Updated deprecated init function in FairPlayDRMParams
Fixed Int enums to implement CustomStringConvertible and have the description function instead of an asString function.
Added missing KalturaBooleanValue object arriving in the metas.
Added the metas, the recording id and the recording type to the metadata in the PKMediaEntry.
Set the asset reference type to npvr if it was not set, in case the media type is recording.
Fixed the dependency to PlayKit in the podspec file.