### PR TITLE
FEC-9935 The media protocol in Pheonix is not sent correctly.

### DIFF
--- a/Sources/OTT/Provider/PhoenixMediaProvider.swift
+++ b/Sources/OTT/Provider/PhoenixMediaProvider.swift
@@ -367,7 +367,7 @@ public enum PhoenixMediaProviderError: PKError {
         let multiRequestBuilder = KalturaMultiRequestBuilder(url: loaderInfo.sessionProvider.serverURL)?.setOTTBasicParams()
         
         let playbackContextOptions = PlaybackContextOptions(playbackContextType: loaderInfo.playbackContextType,
-                                                            protocls: [loaderInfo.networkProtocol],
+                                                            mediaProtocol: loaderInfo.networkProtocol,
                                                             assetFileIds: loaderInfo.fileIds,
                                                             referrer: self.referrer)
         

--- a/Sources/OTT/Services/OTTAssetService.swift
+++ b/Sources/OTT/Services/OTTAssetService.swift
@@ -43,7 +43,7 @@ class OTTAssetService {
 struct PlaybackContextOptions {
 
     var playbackContextType: PlaybackTypeAPI
-    var protocls: [String]
+    var mediaProtocol: String?
     var assetFileIds: [String]?
     var referrer: String?
     
@@ -51,7 +51,7 @@ struct PlaybackContextOptions {
 
         var dict: [String: Any] = [:]
         dict["context"] = playbackContextType.description
-        dict["mediaProtocols"] = protocls
+        dict["mediaProtocol"] = mediaProtocol
         if let fileIds = self.assetFileIds {
             dict["assetFileIds"] = fileIds.joined(separator: ",")
         }


### PR DESCRIPTION
### Description of the Changes

The data sent should be mediaProtocol which receives a string.

Solves FEC-9935