### PR TITLE
FEC-10474 Rename class 'USRExecutor' to 'KNKRequestExecutor'

### DIFF
--- a/PlayKitProviders.podspec
+++ b/PlayKitProviders.podspec
@@ -18,10 +18,10 @@ Pod::Spec.new do |s|
 
   s.source_files = 'Sources/**/*'
   
-  s.dependency 'PlayKit/AnalyticsCommon', '~> 3.11'
+  s.dependency 'PlayKit/AnalyticsCommon', '~> 3.18'
     
-  s.dependency 'KalturaNetKit', '~> 1.3'
-  s.dependency 'PlayKitUtils'
+  s.dependency 'KalturaNetKit', '~> 1.4'
+  s.dependency 'PlayKitUtils', '~> 0.5'
   s.dependency 'SwiftyXMLParser', '5.0.0'
 end
 

--- a/Sources/OTT/Analytics/BaseOTTAnalyticsPlugin.swift
+++ b/Sources/OTT/Analytics/BaseOTTAnalyticsPlugin.swift
@@ -192,7 +192,7 @@ public class BaseOTTAnalyticsPlugin: BasePlugin, OTTAnalyticsPluginProtocol, App
     }
     
     func send(request: Request) {
-        USRExecutor.shared.send(request: request)
+        KNKRequestExecutor.shared.send(request: request)
     }
     
     /************************************************************/

--- a/Sources/OTT/Analytics/Phoenix/PhoenixAnalyticsPlugin.swift
+++ b/Sources/OTT/Analytics/Phoenix/PhoenixAnalyticsPlugin.swift
@@ -50,7 +50,7 @@ public class PhoenixAnalyticsPlugin: BaseOTTAnalyticsPlugin {
     
     override func buildRequest(ofType type: OTTAnalyticsEventType) -> Request? {
         guard !config.ks.isEmpty else {
-            PKLog.verbose("Analytics not sent, ks is empty.")
+            PKLog.debug("Analytics not sent, ks is empty.")
             return nil
         }
         
@@ -82,7 +82,7 @@ public class PhoenixAnalyticsPlugin: BaseOTTAnalyticsPlugin {
                                                                                     fileId: fileId ?? "") else { return nil }
         
         requestBuilder.set { (response: Response) in
-            PKLog.verbose("Response: \(response)")
+            PKLog.debug("Response: \(response)")
             if response.statusCode == 0 {
                 PKLog.verbose("\(String(describing: response.data))")
                 guard let data = response.data as? [String: Any] else { return }

--- a/Sources/OTT/Provider/PhoenixMediaProvider.swift
+++ b/Sources/OTT/Provider/PhoenixMediaProvider.swift
@@ -266,7 +266,7 @@ public enum PhoenixMediaProviderError: PKError {
     }
     
     /// - Parameter executor: executor which will be used to send request.
-    ///    default is USRExecutor
+    ///    default is KNKRequestExecutor
     /// - Returns: Self
     @discardableResult
     @nonobjc public func set(executor: RequestExecutor?) -> Self {
@@ -337,7 +337,7 @@ public enum PhoenixMediaProviderError: PKError {
         }
         
         let pr = self.networkProtocol ?? defaultProtocol
-        let executor = self.executor ?? USRExecutor.shared
+        let executor = self.executor ?? KNKRequestExecutor.shared
         
         let loaderParams = LoaderInfo(sessionProvider: sessionProvider,
                                       assetId: assetId,

--- a/Sources/OVP/Provider/OVPMediaProvider.swift
+++ b/Sources/OVP/Provider/OVPMediaProvider.swift
@@ -150,7 +150,7 @@ import PlayKit
         let loaderInfo = LoaderInfo(sessionProvider: sessionProvider,
                                     entryId: entryId,
                                     uiconfId: self.uiconfId,
-                                    executor: executor ?? USRExecutor.shared)
+                                    executor: executor ?? KNKRequestExecutor.shared)
         
         self.startLoading(loadInfo: loaderInfo, callback: callback)
     }


### PR DESCRIPTION
Updated renamed class in KalturaNetKit, from USRExecutor to KNKRequestExecutor.
Updated dependency for PlayKit, KalturaNetKit and PlayKitUtils to latest versions.
Updated to debug log instead of verbose, this is needed for debugging.

Solves FEC-10474