### PR TITLE
FEC-10610 Add streamerType into the getPlaybackContext

### DIFF
--- a/Sources/OTT/Provider/PhoenixMediaProvider.swift
+++ b/Sources/OTT/Provider/PhoenixMediaProvider.swift
@@ -180,6 +180,7 @@ public enum PhoenixMediaProviderError: PKError {
     @objc public var networkProtocol: String?
     @objc public var referrer: String?
     @objc public var urlType: String?
+    @objc public var streamerType: String?
     
     public weak var responseDelegate: PKMediaEntryProviderResponseDelegate? = nil
     
@@ -274,6 +275,14 @@ public enum PhoenixMediaProviderError: PKError {
         return self
     }
     
+    /// - Parameter streamerType: the streamer type
+    /// - Returns: Self
+    @discardableResult
+    @nonobjc public func set(streamerType: String?) -> Self {
+        self.streamerType = streamerType
+        return self
+    }
+    
     /// - Parameter executor: executor which will be used to send request.
     ///    default is KNKRequestExecutor
     /// - Returns: Self
@@ -305,6 +314,7 @@ public enum PhoenixMediaProviderError: PKError {
         var fileIds: [String]?
         var networkProtocol: String
         var urlType: String?
+        var streamerType: String?
         var executor: RequestExecutor
     }
     
@@ -358,6 +368,7 @@ public enum PhoenixMediaProviderError: PKError {
                                       fileIds: self.fileIds,
                                       networkProtocol: pr,
                                       urlType: self.urlType,
+                                      streamerType: self.streamerType,
                                       executor: executor)
         
         self.startLoad(loaderInfo: loaderParams, callback: callback)
@@ -381,7 +392,8 @@ public enum PhoenixMediaProviderError: PKError {
                                                             mediaProtocol: loaderInfo.networkProtocol,
                                                             assetFileIds: loaderInfo.fileIds,
                                                             referrer: self.referrer,
-                                                            urlType: loaderInfo.urlType)
+                                                            urlType: loaderInfo.urlType,
+                                                            streamerType: self.streamerType)
         
         var ksString: String
         

--- a/Sources/OTT/Services/OTTAssetService.swift
+++ b/Sources/OTT/Services/OTTAssetService.swift
@@ -47,6 +47,7 @@ struct PlaybackContextOptions {
     var assetFileIds: [String]?
     var referrer: String?
     var urlType: String?
+    var streamerType: String?
     
     func toDictionary() -> [String: Any] {
 
@@ -61,6 +62,9 @@ struct PlaybackContextOptions {
         }
         if let urlType = self.urlType {
             dict["urlType"] = urlType
+        }
+        if let streamerType = self.streamerType {
+            dict["streamerType"] = streamerType
         }
         return dict
     }


### PR DESCRIPTION
Added streamerType to the options sent for the getPlaybackContext request for OTT.

Solves FEC-10610