### PR TITLE
FEC-10758 Added disableMediaHit and disableMediaMark to the OTTAnalyt…

### DIFF
--- a/Sources/OTT/Analytics/BaseOTTAnalyticsPlugin.swift
+++ b/Sources/OTT/Analytics/BaseOTTAnalyticsPlugin.swift
@@ -27,23 +27,23 @@ public class BaseOTTAnalyticsPlugin: BasePlugin, OTTAnalyticsPluginProtocol, App
     var mediaId: String?
     var stopSentByDestroy: Bool = false
     
-    var ottAnalyticsPluginConfig: OTTAnalyticsPluginConfig?
+    var disableMediaHit: Bool = false
+    var disableMediaMark: Bool = false
     
     /************************************************************/
     // MARK: - Private
     /************************************************************/
 
     private func shouldSendAnalyticsEvent(ofType type: OTTAnalyticsEventType) -> Bool {
-        guard let analyticsPluginConfig = ottAnalyticsPluginConfig else { return true }
         
         let isHitEvent: Bool = type == .hit
         
-        if isHitEvent && analyticsPluginConfig.disableMediaHit {
+        if isHitEvent && disableMediaHit {
             PKLog.info("Media Hit Event Report Blocked")
             return false
         }
         
-        if !isHitEvent && analyticsPluginConfig.disableMediaMark {
+        if !isHitEvent && disableMediaMark {
             PKLog.info("Media Mark Event Report Blocked")
             return false
         }
@@ -61,7 +61,6 @@ public class BaseOTTAnalyticsPlugin: BasePlugin, OTTAnalyticsPluginProtocol, App
         self.periodicObserverUUID = self.player?.addPeriodicObserver(interval: 1.0, observeOn: DispatchQueue.main, using: { (time) in
             self.lastPosition = time.toInt32()
         })
-        self.ottAnalyticsPluginConfig = pluginConfig as? OTTAnalyticsPluginConfig
         self.registerEvents()
     }
 

--- a/Sources/OTT/Analytics/OTTAnalyticsPluginConfig.swift
+++ b/Sources/OTT/Analytics/OTTAnalyticsPluginConfig.swift
@@ -14,9 +14,13 @@ import Foundation
     
     let baseUrl: String
     let timerInterval: TimeInterval
+    var disableMediaHit: Bool = false
+    var disableMediaMark: Bool = false
     
-    init(baseUrl: String, timerInterval: TimeInterval) {
+    init(baseUrl: String, timerInterval: TimeInterval, disableMediaHit: Bool = false, disableMediaMark: Bool = false) {
         self.baseUrl = baseUrl
         self.timerInterval = timerInterval
+        self.disableMediaHit = disableMediaHit
+        self.disableMediaMark = disableMediaMark
     }
 }

--- a/Sources/OTT/Analytics/Phoenix/PhoenixAnalyticsPlugin.swift
+++ b/Sources/OTT/Analytics/Phoenix/PhoenixAnalyticsPlugin.swift
@@ -19,6 +19,7 @@ public class PhoenixAnalyticsPlugin: BaseOTTAnalyticsPlugin {
     var config: PhoenixAnalyticsPluginConfig! {
         didSet {
             self.interval = config.timerInterval
+            self.ottAnalyticsPluginConfig = config
         }
     }
     
@@ -29,7 +30,6 @@ public class PhoenixAnalyticsPlugin: BaseOTTAnalyticsPlugin {
             throw PKPluginError.missingPluginConfig(pluginName: PhoenixAnalyticsPlugin.pluginName)
         }
         self.config = config
-        self.interval = config.timerInterval
     }
     
     public override func onUpdateConfig(pluginConfig: Any) {

--- a/Sources/OTT/Analytics/Phoenix/PhoenixAnalyticsPlugin.swift
+++ b/Sources/OTT/Analytics/Phoenix/PhoenixAnalyticsPlugin.swift
@@ -19,7 +19,8 @@ public class PhoenixAnalyticsPlugin: BaseOTTAnalyticsPlugin {
     var config: PhoenixAnalyticsPluginConfig! {
         didSet {
             self.interval = config.timerInterval
-            self.ottAnalyticsPluginConfig = config
+            self.disableMediaHit = config.disableMediaHit
+            self.disableMediaMark = config.disableMediaMark
         }
     }
     

--- a/Sources/OTT/Analytics/Phoenix/PhoenixAnalyticsPluginConfig.swift
+++ b/Sources/OTT/Analytics/Phoenix/PhoenixAnalyticsPluginConfig.swift
@@ -12,9 +12,14 @@ import Foundation
     let ks: String
     let partnerId: Int
     
-    @objc public init(baseUrl: String, timerInterval: TimeInterval, ks: String, partnerId: Int) {
+    @objc public init(baseUrl: String,
+                      timerInterval: TimeInterval,
+                      ks: String,
+                      partnerId: Int,
+                      disableMediaHit: Bool = false,
+                      disableMediaMark: Bool = false) {
         self.ks = ks
         self.partnerId = partnerId
-        super.init(baseUrl: baseUrl, timerInterval: timerInterval)
+        super.init(baseUrl: baseUrl, timerInterval: timerInterval, disableMediaHit: disableMediaHit, disableMediaMark: disableMediaMark)
     }
 }


### PR DESCRIPTION
Solves FEC-10758
Added disableMediaHit and disableMediaMark to the OTTAnalyticsPluginConfig.

Fixed reporting the event to the messageBus only when it will be sent.
Removed setting the timer interval again after it was set when the config was set.