### PR TITLE
FEC-12124 Add YouTube referenceId support.

### DIFF
--- a/Sources/OVP/Model/OVPEntry.swift
+++ b/Sources/OVP/Model/OVPEntry.swift
@@ -21,6 +21,7 @@ enum EntryType: Int {
 class OVPEntry: OVPBaseObject {
     
     var id: String
+    var referenceId: String?
     var dataURL: URL?
     var mediaType: Int?
     var flavorParamsIds: String?
@@ -31,6 +32,7 @@ class OVPEntry: OVPBaseObject {
     var thumbnailUrl: String?
     
     let idKey = "id"
+    var referenceIdKey = "referenceId"
     let dataURLKey = "dataUrl"
     let mediaTypeKey = "mediaType"
     let flavorParamsIdsKey = "flavorParamsIds"
@@ -61,6 +63,7 @@ class OVPEntry: OVPBaseObject {
         self.type = jsonObject[typeKey].int
         self.tags = jsonObject[tagsKey].string
         self.thumbnailUrl = jsonObject[thumbnailUrlKey].string
+        self.referenceId = jsonObject[referenceIdKey].string
     }
     
     func entryType() -> EntryType? {

--- a/Sources/OVP/Model/OVPExternalMediaEntry.swift
+++ b/Sources/OVP/Model/OVPExternalMediaEntry.swift
@@ -1,0 +1,27 @@
+// ===================================================================================================
+// Copyright (C) 2022 Kaltura Inc.
+//
+// Licensed under the AGPLv3 license, unless a different license for a
+// particular library is specified in the applicable library path.
+//
+// You may obtain a copy of the License at
+// https://www.gnu.org/licenses/agpl-3.0.html
+// ===================================================================================================
+
+import Foundation
+import SwiftyJSON
+
+class OVPExternalMediaEntry: OVPEntry {
+    
+    var externalSourceType: String?
+    
+    let externalSourceTypeKey = "externalSourceType"
+    
+    required init?(json: Any) {
+        super.init(json: json)
+        
+        let jsonObject = JSON(json)
+        self.externalSourceType = jsonObject[externalSourceTypeKey].string
+    }
+    
+}

--- a/Sources/OVP/Parsers/OVPObjectMapper.swift
+++ b/Sources/OVP/Parsers/OVPObjectMapper.swift
@@ -43,6 +43,8 @@ class OVPObjectMapper: NSObject {
                 return OVPMetadataList.self
             case "KalturaPlaylist":
                 return OVPPlaylist.self
+            case "KalturaExternalMediaEntry":
+                return OVPExternalMediaEntry.self
             default:
                 return nil
             }

--- a/Sources/OVP/Provider/OVPMediaProvider.swift
+++ b/Sources/OVP/Provider/OVPMediaProvider.swift
@@ -336,13 +336,19 @@ public enum OVPMediaProviderError: PKError {
                         
                         if let sources = sources,
                            baseEntry.externalSourceType != "YouTube" && sources.isEmpty {
-                            PKLog.debug("Response is not containing entry info or playback data.")
+                            PKLog.debug("Response is not containing playback data.")
                             callback(nil, OVPMediaProviderError.invalidResponse)
                             return
                         }
                         
                         metaDataItems["externalSourceType"] = baseEntry.externalSourceType
                         metaDataItems["referenceId"] = baseEntry.referenceId
+                    } else {
+                        if let sources = sources, sources.isEmpty {
+                            PKLog.debug("Response is not containing playback data.")
+                            callback(nil, OVPMediaProviderError.invalidResponse)
+                            return
+                        }
                     }
                     
                     mediaEntry.name = baseEntry.name


### PR DESCRIPTION
Solves FEC-12124
Added YouTube referenceId support.

```Swift
mediaProvider.loadMedia { (mediaEntry, error) in
            
            if let externalSourceType = mediaEntry?.metadata?["externalSourceType"],
               externalSourceType == "YouTube" {
                
                print("YouTube is Playing: \(mediaEntry?.metadata?["referenceId"])")
                
            } else {
                if let me = mediaEntry, error == nil {
                    // create media config
                    let mediaConfig = MediaConfig(mediaEntry: me, startTime: 0.0)
                    
                    // prepare the player
                    self.player!.prepare(mediaConfig)
                }
            }
        }
```